### PR TITLE
Remove extra greater than from Martin

### DIFF
--- a/directory.md
+++ b/directory.md
@@ -119,7 +119,7 @@ Se även [förteckningen på Working with Rails](http://www.workingwithrails.com
       <li>Fredrik Bränström</li>
       <li>Jens Berlips</li>
       <li>Johan Lundström</li>
-      <li>Martin Larsson></li>
+      <li>Martin Larsson</li>
       <li>Mathias Klippinge</li>
       <li>Michael Litton</li>
     </ul>


### PR DESCRIPTION
Fixes a minor typo.
