### PR TITLE
Remove people from teams

### DIFF
--- a/directory.md
+++ b/directory.md
@@ -1,6 +1,6 @@
 ---
 layout: default
-title: Team, projekt och utvecklare
+title: Team
 ---
 
 Långt ifrån komplett! [Lägg gärna till](https://github.com/rails-se/rails-se.github.com/edit/master/directory.md) er själva.
@@ -18,10 +18,6 @@ Långt ifrån komplett! [Lägg gärna till](https://github.com/rails-se/rails-se
 <ul>
   <li>
     <a href="http://mittmedia.se">MittMedia</a>
-    <ul>
-      <li>Roger Nyström</li>
-      <li>Tony Klintasp</li>
-     </ul>
   </li>
 </ul>
 
@@ -30,79 +26,34 @@ Långt ifrån komplett! [Lägg gärna till](https://github.com/rails-se/rails-se
 <ul>
   <li>
     <a href="http://mittmedia.se">MittMedia</a>
-    <ul>
-      <li>
-        Fredrik Sundström
-        {% assign twitter = 'designfredrik' %}{% include twitter.html %}
-        {% assign github = 'fredriksundstrom' %}{% include github.html %}
-      </li>
-      <li>Magnus Engström</li>
-     </ul>
   </li>
+
   <li>
     <a>FSH Sweden AB</a>
-    <ul>
-      <li>
-        Peter Andersson
-        {% assign twitter = 'fshsweden' %}{% include twitter.html %}
-        {% assign github = 'fshsweden' %}{% include github.html %}
-      </li>
-     </ul>
   </li>
 </ul>
 
 ## Göteborg
 
 <ul>
-
-  <li>
-    <a href="http://elabs.se">Elabs</a>
-  </li>
-
   <li>
     <a href="http://www.ibissoft.se">IbisSoft</a>
-    <ul>
-      <li>
-        Rogier Krona
-        {% assign twitter = 'RogTheFox' %}{% include twitter.html %}
-        {% assign github = 'RogTheFox' %}{% include github.html %}
-      </li>
-      <li>
-        Tomas Andersson
-        {% assign github = 'telimbectar' %}{% include github.html %}
-      </li>
-    </ul>
   </li>
 
   <li>
-  <a href="http://kyparn.se">Kyparn.se</a>
-  <ul>
-    <li>
-      <a href="http://mattiassvedhem.com/">Mattias Svedhem</a>
-      {% assign twitter = 'mattiassvedhem' %}{% include twitter.html %}
-      {% assign github = 'mattiassvedhem' %}{% include github.html %}
-    </li>
-  </ul>
+    <a href="http://kyparn.se">Kyparn.se</a>
   </li>
 
   <li>
     <a href="http://varvet.se">Varvet</a>
   </li>
-
 </ul>
 
 ## Karlskrona
 
 <ul>
   <li>
-  <a href="http://modondo.com">Modondo</a>
-  <ul>
-    <li>
-      <a href="http://jorgennilsson.com/">Jörgen Nilsson</a>
-      {% assign twitter = 'coffeepunk' %}{% include twitter.html %}
-      {% assign github = 'coffeepunk' %}{% include github.html %}
-    </li>
-  </ul>
+    <a href="http://modondo.com">Modondo</a>
   </li>
 </ul>
 
@@ -110,43 +61,15 @@ Långt ifrån komplett! [Lägg gärna till](https://github.com/rails-se/rails-se
 
 <ul>
   <li>
-  <a href="http://xlent.se">XLENT</a>
-  <ul>
-    <li>
-      <a href="http://rny.io/">Richard Nyström</a>
-      {% assign twitter = 'richardnystrom' %}{% include twitter.html %}
-      {% assign github = 'ricn' %}{% include github.html %}
-    </li>
-  </ul>
+    <a href="http://xlent.se">XLENT</a>
   </li>
 </ul>
 
 ## Linköping
 
 <ul>
-
   <li>
     <a href="http://www.twingly.com">Twingly</a>
-    {% assign github = 'Twingly' %}{% include github.html %}
-    <ul>
-      <li>
-        Johan Eckerström
-        {% assign github = 'jage' %}{% include github.html %}
-      </li>
-      <li>
-        Magnus Hörberg
-        {% assign github = 'magnushoerberg' %}{% include github.html %}
-      </li>
-      <li>
-        Mattias Roback
-        {% assign github = 'roback' %}{% include github.html %}
-      </li>
-      <li>
-        Patrik Ragnarsson
-        {% assign twitter = 'dentarg_' %}{% include twitter.html %}
-        {% assign github = 'dentarg' %}{% include github.html %}
-      </li>
-    </ul>
   </li>
 </ul>
 
@@ -154,323 +77,90 @@ Långt ifrån komplett! [Lägg gärna till](https://github.com/rails-se/rails-se
 <ul>
   <li>
     <a href="http://www.codehacker.se">Codehacker</a>
-    <ul>
-      <li>
-        Karl Metum
-        {% assign twitter = 'karlingen' %}{% include twitter.html %}
-        {% assign github = 'karlingen' %}{% include github.html %}
-      </li>
-     </ul>
   </li>
 </ul>
 
 ## Stockholm
 
 <ul>
-
   <li>
     <a href="http://www.apoex.se.">ApoEx</a>
-    <ul>
-      <li>Andreas Karlsson</li>
-      <li>Daniel Swärd</li>
-      <li>Frans Krojegård</li>
-      <li>Fredrik Bränström</li>
-      <li>Jens Berlips</li>
-      <li>Johan Lundström</li>
-      <li>Martin Larsson</li>
-      <li>Mathias Klippinge</li>
-      <li>Michael Litton</li>
-    </ul>
   </li>
 
   <li>
     <a href="http://www.aptilo.com">Aptilo Networks</a>
-    <ul>
-      <li>Linus Sellberg</li>
-    </ul>
   </li>
 
   <li>
     <a href="https://auctionet.com">Auctionet.com</a>
-    <ul>
-      <li>Albert Ramstedt</li>
-      <li>
-        <a href="http://henrik.nyh.se">Henrik Nyh</a>
-        {% assign twitter = 'henrik' %}{% include twitter.html %}
-        {% assign github = 'henrik' %}{% include github.html %}
-      </li>
-      <li>
-        Joakim Kolsjö
-        {% assign twitter = 'joakimk' %}{% include twitter.html %}
-        {% assign github = 'joakimk' %}{% include github.html %}
-      </li>
-      <li>
-        Kim Persson
-        {% assign twitter = 'Lavinia666' %}{% include twitter.html %}
-        {% assign github = 'Lavinia' %}{% include github.html %}
-      </li>
-      <li>
-        Tomas Skogberg
-        {% assign twitter = 'tskogberg' %}{% include twitter.html %}
-        {% assign github = 'tskogberg' %}{% include github.html %}
-      </li>
-    </ul>
   </li>
 
   <li>
     <a href="https://baraspara.se/">Baraspara.se</a>
   </li>
-  
+
   <li>
     <a href="https://github.com/beardlesshq">Beardless AB</a>
-    <ul>
-      <li>
-        <a href="http://www.martinholmin.se/">Martin Holmin</a>
-        {% assign twitter = 'martinholmin' %}{% include twitter.html %}
-        {% assign github = 'martinholmin' %}{% include github.html %}
-      </li>
-    </ul>
   </li>
 
   <li>
     <a href="http://bukowskis.com">Bukowskis</a>
-    <ul>
-      <li>
-        Daniel Eriksson
-        {% assign twitter = 'danieleriksson' %}{% include twitter.html %}
-        {% assign github = 'daniel' %}{% include github.html %}
-      </li>
-    </ul>
   </li>
+
   <li>
     <a href="http://www.hemnet.se">Hemnet</a>
   </li>
+
   <li>
     <a href="http://www.ibissoft.se">IbisSoft</a>
-    <ul>
-      <li>
-        Rogier Krona
-        {% assign twitter = 'RogTheFox' %}{% include twitter.html %}
-        {% assign github = 'RogTheFox' %}{% include github.html %}
-      </li>
-      <li>
-        Alexey Stryi
-        {% assign github = 'alexey-stryi' %}{% include github.html %}
-      </li>
-      <li>
-        Tomas Andersson
-        {% assign github = 'telimbectar' %}{% include github.html %}
-      </li>
-      <li>
-        Mattias Creutzberg
-        {% assign github = 'SetOfIdentifiers' %}{% include github.html %}
-      </li>
-    </ul>
   </li>
+
   <li>
     <a href="http://www.itsinthenode.com">Its in the Node</a>
   </li>
+
   <li>
     <a href="http://justarrived.se">Just Arrived</a>
-    <ul>
-      <li>
-        Jacob Burenstam
-        {% assign twitter = 'bnuren' %}{% include twitter.html %}
-        {% assign github = 'buren' %}{% include github.html %}
-      </li>
-    </ul>
   </li>
+
   <li>
     <a href="http://www.jmkplay.se">JMK, Stockholms universitet</a>
   </li>
+
   <li>
     <a href="http://www.kollegorna.se">Kollegorna</a>
-    <ul>
-      <li>
-        <a href="http://henriksjokvist.net">Henrik Sjökvist</a>
-        {% assign twitter = 'henrrrik' %}{% include twitter.html %}
-        {% assign github = 'henrrrik' %}{% include github.html %}
-      </li>
-      <li>
-        <a href="http://www.helloper.com">Per Sandström</a>
-          {% assign twitter = 'persand' %}{% include twitter.html %}
-          {% assign github = 'persand' %}{% include github.html %}
-      </li>
-      <li>Samuel Carlsson
-        {% assign github = 'ksamc' %}{% include github.html %}
-      </li>
-      <li>Filippos Vasilakis
-        {% assign github = 'vasilakisfil' %}{% include github.html %}
-      </li>
-      <li>Dennis Carlsson
-        {% assign github = 'dencarlsson' %}{% include github.html %}
-      </li>
-    </ul>
   </li>
+
   <li>
     <a href="http://www.magplus.com">Mag+</a>
-    <ul>
-      <li>
-        Dennis Rogenius
-        {% assign twitter = 'denro' %}{% include twitter.html %}
-        {% assign github = 'denro' %}{% include github.html %}
-      </li>
-      <li>
-        Karl Eklund
-        {% assign twitter = 'keklund' %}{% include twitter.html %}
-        {% assign github = 'kek' %}{% include github.html %}
-      </li>
-      <li>
-        Lennart Fridén
-        {% assign twitter = 'DevLCSC' %}{% include twitter.html %}
-        {% assign github = 'DevL' %}{% include github.html %}
-      </li>
-      <li>
-        Mikael Amborn
-        {% assign twitter = 'mikaelamborn' %}{% include twitter.html %}
-        {% assign github = 'mikaelamborn' %}{% include github.html %}
-      </li>
-    </ul>
   </li>
 
   <li>
     <a href="http://www.mynewsdesk.com">Mynewsdesk</a>
-    <ul>
-      <li>Alex Sergeyev</li>
-      <li>Alexander Woll</li>
-      <li>David Backéus</li>
-      <li>Emil Löfquist</li>
-      <li>Hilla Duka
-        {% assign twitter = 'hilladuka' %}{% include twitter.html %}
-        {% assign github = 'elisabetduka' %}{% include github.html %}
-      </li>
-      <li>Jan Andersson
-        {% assign twitter = 'jan_andersson' %}{% include twitter.html %}
-        {% assign github = 'janne' %}{% include github.html %}
-      </li>
-      <li>
-        <a href="http://joakimolander.se">Joakim Olander</a>
-        {% assign twitter = 'hellojorkas' %}{% include twitter.html %}
-        {% assign github = 'jorkas' %}{% include github.html %}
-      </li>
-      <li>
-        <a href="http://dribbble.com/joelhelin">Joel Helin</a>
-        {% assign twitter = 'joelhelin' %}{% include twitter.html %}
-        {% assign github = 'joelhelin' %}{% include github.html %}
-      </li>
-      <li>Kristian Hellquist</li>
-      <li>Markus Nordin</li>
-      <li>
-        Martin Svalin
-        {% assign twitter = 'martinsvalin' %}{% include twitter.html %}
-        {% assign github = 'martinsvalin' %}{% include github.html %}
-      </li>
-      <li>Yu Wang</li>
-      <li>
-        <a href="http://zoeetrope.com">Zoee Silcock</a>
-        {% assign twitter = 'zoees' %}{% include twitter.html %}
-        {% assign github = 'zoeesilcock' %}{% include github.html %}
-      </li>
-    </ul>
   </li>
 
   <li>
     <a href="http://oktavilla.se">Oktavilla</a>
-    <ul>
-      <li>
-        Arvid Andersson
-        {% assign twitter = 'arvid_a' %}{% include twitter.html %}
-        {% assign github = 'arvida' %}{% include github.html %}
-      </li>
-      <li>
-        Alexis Fellenius
-        {% assign twitter = 'alexisfellenius' %}{% include twitter.html %}
-        {% assign github = 'lexi' %}{% include github.html %}
-      </li>
-      <li>
-        Joel Junström
-        {% assign twitter = 'joeljunstrom' %}{% include twitter.html %}
-        {% assign github = 'joeljunstrom' %}{% include github.html %}
-      </li>
-     </ul>
   </li>
 
   <li>
     <a href="http://onegiantleap.se">One Giant Leap</a>
-    <ul>
-      <li>
-        Tim Heighes
-        {% assign twitter = 'sauy7' %}{% include twitter.html %}
-        {% assign github = 'sauy7' %}{% include github.html %}
-      </li>
-    </ul>
   </li>
 
   <li>
     <a href="http://www.promoterapp.com">Promoter</a>
-    <ul>
-      <li>
-        Andreas Zecher
-        {% assign twitter = 'andreaszecher' %}{% include twitter.html %}
-        {% assign github = 'pixelate' %}{% include github.html %}
-      </li>
-    </ul>
   </li>
 
   <li>
     <a href="mailto:peter@lind.be">Supermåne</a>
-    <ul>
-      <li>
-        Peter Lind
-        {% assign twitter = 'peter_lind' %}{% include twitter.html %}
-        {% assign github = 'peterlind' %}{% include github.html %}
-      </li>
-    </ul>
   </li>
 
   <li>
     <a href="http://www.teamtailor.com">Teamtailor</a>
-    <ul>
-      <li>
-        David Wennergren
-      </li>
-      <li>
-        <a href="http://jonasforsberg.se">Jonas Brusman</a>
-        {% assign twitter = 'himynameisjonas' %}{% include twitter.html %}
-        {% assign github = 'himynameisjonas' %}{% include github.html %}
-      </li>
-      <li>
-        Richard Johansson
-        {% assign twitter = 'richardjohansso' %}{% include twitter.html %}
-        {% assign github = 'richardjohansson' %}{% include github.html %}
-      </li>
-    </ul>
-  </li>
-
-  <li>
-    <a href="https://travellersmatch.com">Travellersmatch</a>
-    <ul>
-      <li>
-        Tim Heighes
-        {% assign twitter = 'sauy7' %}{% include twitter.html %}
-        {% assign github = 'sauy7' %}{% include github.html %}
-      </li>
-    </ul>
   </li>
 
   <li>
     <a href="http://www.triceimaging.com/">Trice Imaging</a>
-    <ul>
-      <li>
-        <a href="http://eimermusic.com/">Martin Westin</a>
-        {% assign twitter = 'eimer' %}{% include twitter.html %}
-        {% assign github = 'eimermusic' %}{% include github.html %}
-      </li>
-      <li>
-        John Axel Eriksson
-        {% assign github = 'johnae' %}{% include github.html %}
-      </li>
-    </ul>
   </li>
 
   <li>
@@ -487,41 +177,18 @@ Långt ifrån komplett! [Lägg gärna till](https://github.com/rails-se/rails-se
 
   <li>
     <a href="http://whisprgroup.com">WhisprGroup (mediapilot)</a>
-    <ul>
-      <li>
-        Tim Heighes
-        {% assign twitter = 'sauy7' %}{% include twitter.html %}
-        {% assign github = 'sauy7' %}{% include github.html %}
-      </li>
-    </ul>
   </li>
-
 </ul>
 
 ## Sundsvall
 
 <ul>
-<li>
-  <a href="http://mittmedia.se">MittMedia</a>
-  <ul>
-    <li>Anders Härén</li>
-    <li>Andreas Svanberg</li>
-    <li>
-      Erik Nordlund
-      {% assign twitter = 'nerikj' %}{% include twitter.html %}
-      {% assign github = 'eriknordlund' %}{% include github.html %}
-    </li>
-   </ul>
-</li>
-<li>
+  <li>
+    <a href="http://mittmedia.se">MittMedia</a>
+  </li>
+
+  <li>
     <a href="http://savecore.se">Savecore</a>
-    <ul>
-      <li>
-        Gustaf Lindqvist
-        {% assign twitter = 'glindqvist' %}{% include twitter.html %}
-        {% assign github = 'gustaflindqvist' %}{% include github.html %}
-      </li>
-     </ul>
   </li>
 </ul>
 
@@ -530,33 +197,13 @@ Långt ifrån komplett! [Lägg gärna till](https://github.com/rails-se/rails-se
 <ul>
   <li>
     <a href="http://sandeli.us">Tobias Sandelius</a>
-    {% assign twitter = 'sandelius' %}{% include twitter.html %}
-    {% assign github = 'sandelius' %}{% include github.html %}
   </li>
+
   <li>
     <a href="http://midnightoil.se/">Layla Alvey</a>
-    {% assign twitter = 'NiteOL' %}{% include twitter.html %}
-    {% assign github = 'codinatrix' %}{% include github.html %}
   </li>
+
   <li>
     <a href="http://standout.se/">Standout AB</a>
-    {% assign twitter = 'standoutab' %}{% include twitter.html %}
-    {% assign github = 'standout' %}{% include github.html %}
-  </li>
-</ul>
-
-
-## USA/Stockholm
-
-<ul>
-  <li>
-    <a href="http://hashrocket.com/">Hashrocket</a>
-    <ul>
-      <li>
-        Ingemar Edsborn
-        {% assign twitter = 'ingmr' %}{% include twitter.html %}
-        {% assign github = 'ingemar' %}{% include github.html %}
-      </li>
-    </ul>
   </li>
 </ul>

--- a/index.md
+++ b/index.md
@@ -18,7 +18,7 @@ layout: default
 ## Resurser
 
 * [Tips för svenska applikationer](/tips)
-* [Team, projekt och utvecklare](/directory)
+* [Team](/directory)
 
 ## Legacy
 


### PR DESCRIPTION
Companies come and go, and so do their employees. Some companies in the
community have had quite the turmoil in terms of their staffing, and
most the list of employees are out of date.

To mitigate that fact, I am removing the list of employees of each
company. If you want to get in touch with someone, do so over our Chat
or go to a meetup.