### PR TITLE
Gemfile.lock: Update nokogiri to 1.8.1 - security

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -158,14 +158,14 @@ GEM
       rb-fsevent (>= 0.9.3)
       rb-inotify (>= 0.9.7)
     mercenary (0.3.6)
-    mini_portile2 (2.2.0)
+    mini_portile2 (2.3.0)
     minima (2.1.1)
       jekyll (~> 3.3)
     minitest (5.10.2)
     multipart-post (2.0.0)
     net-dns (0.8.0)
-    nokogiri (1.8.0)
-      mini_portile2 (~> 2.2.0)
+    nokogiri (1.8.1)
+      mini_portile2 (~> 2.3.0)
     octokit (4.7.0)
       sawyer (~> 0.8.0, >= 0.5.3)
     pathutil (0.14.0)
@@ -200,4 +200,4 @@ DEPENDENCIES
   github-pages
 
 BUNDLED WITH
-   1.15.2
+   1.16.1


### PR DESCRIPTION
In order to avoid the security warning in GitHub, update the nokogiri package to 1.8.1.