### PR TITLE
Fix CVE-2019-5477: Use Nokogiri 1.10.4

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -205,7 +205,7 @@ GEM
       jekyll-seo-tag (~> 2.1)
     minitest (5.11.3)
     multipart-post (2.0.0)
-    nokogiri (1.10.1)
+    nokogiri (1.10.4)
       mini_portile2 (~> 2.4.0)
     octokit (4.13.0)
       sawyer (~> 0.8.0, >= 0.5.3)


### PR DESCRIPTION
This fixes the CVE reported by GitHub's automatic vuln alerts.