### PR TITLE
Adjust Fishbrain Vacancies link

### DIFF
--- a/directory.md
+++ b/directory.md
@@ -108,7 +108,7 @@ Långt ifrån komplett! [Lägg gärna till](https://github.com/rails-se/rails-se
   </li>
   
   <li>
-  <a href="https://fishbrain.com">Fishbrain</a> (<a href="https://fishbrain.com/jobs/">Vacancies</a>)
+  <a href="https://fishbrain.com">Fishbrain</a> (<a href="https://careers.fishbrain.com/">Vacancies</a>)
   </li>
 
   <li>


### PR DESCRIPTION
This is just a small adjustment to the link to Fishbrain's vacancies.