### PR TITLE
Add Shopify to list of Ruby companies in Stockholm

### DIFF
--- a/directory.md
+++ b/directory.md
@@ -156,6 +156,10 @@ Långt ifrån komplett! [Lägg gärna till](https://github.com/rails-se/rails-se
   </li>
 
   <li>
+    <a href="https://www.shopify.com/">Shopify</a>
+  </li>
+
+  <li>
     <a href="mailto:peter@lind.be">Supermåne</a>
   </li>
 


### PR DESCRIPTION
The Shopify office was opened in Stockholm in November 2018 and we're known in the Ruby community. We'd love to be listed on your page. Thanks 