### PR TITLE
Use Bundler 2.6.6

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -264,4 +264,4 @@ DEPENDENCIES
   github-pages
 
 BUNDLED WITH
-   1.17.3
+   2.6.6


### PR DESCRIPTION
This allows Dependabot to update gems.